### PR TITLE
Show language icons in selector

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -244,7 +244,7 @@ img {
     color: var(--color-text-secondary);
     border: 1px solid var(--color-text-secondary);
     padding-block: var(--spacing-xs);
-    padding-inline-start: 0.8rem;
+    padding-inline-start: 2rem;
     padding-inline-end: 2.2rem;
     border-radius: 4px;
     font-family: var(--font-sans);
@@ -252,9 +252,10 @@ img {
     font-weight: 600;
     cursor: pointer;
     transition: color var(--transition-speed) ease, border-color var(--transition-speed) ease;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23a8b2d1'%3E%3Cpath d='M6 9.25a.75.75 0 01-.53-.22l-3-3a.75.75 0 011.06-1.06L6 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-.53.22z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 0.75rem center;
+    background-image: url('tr.png'), url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23a8b2d1'%3E%3Cpath d='M6 9.25a.75.75 0 01-.53-.22l-3-3a.75.75 0 011.06-1.06L6 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-.53.22z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat, no-repeat;
+    background-position: 0.4rem center, right 0.75rem center;
+    background-size: 1rem auto, 12px;
 }
 
 .lang-select:hover, .lang-select:focus {
@@ -265,7 +266,15 @@ img {
 .lang-select option {
     background-color: var(--color-background);
     color: var(--color-text-primary);
+    padding-inline-start: 2rem;
+    background-repeat: no-repeat;
+    background-position: 0.4rem center;
+    background-size: 1rem auto;
 }
+
+.lang-select option[value="tr"] { background-image: url('tr.png'); }
+.lang-select option[value="en"] { background-image: url('en.png'); }
+.lang-select option[value="ar"] { background-image: url('ar.png'); }
 
 
 /* --- Hamburger Menü (Mobil) --- */

--- a/index.html
+++ b/index.html
@@ -65,9 +65,9 @@
                 <div class="lang-switcher">
                     <label for="lang-select" class="sr-only" data-i18n-key="lang_select_label">Dil Seçin</label>
                     <select id="lang-select" class="lang-select">
-                        <option value="tr">🇹🇷 TR</option>
-                        <option value="en">🇬🇧 EN</option>
-                        <option value="ar">🇦🇪 AR</option>
+                        <option value="tr" data-icon="tr.png">TR</option>
+                        <option value="en" data-icon="en.png">EN</option>
+                        <option value="ar" data-icon="ar.png">AR</option>
                     </select>
                 </div>
             </nav>

--- a/index.js
+++ b/index.js
@@ -77,6 +77,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const supportedLangs = ['en', 'tr', 'ar'];
     const defaultLang = 'tr';
 
+    const arrowIcon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23a8b2d1'%3E%3Cpath d='M6 9.25a.75.75 0 01-.53-.22l-3-3a.75.75 0 011.06-1.06L6 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-.53.22z'/%3E%3C/svg%3E";
+    const iconMap = { en: 'en.png', tr: 'tr.png', ar: 'ar.png' };
+    const setLangIcon = (lang) => {
+        if (!langSelect) return;
+        const icon = iconMap[lang];
+        if (icon) {
+            langSelect.style.backgroundImage = `url(${icon}), url(${arrowIcon})`;
+        }
+    };
+
     const setupNavigation = () => {
         const navLinks = document.querySelectorAll('.main-nav a[href^="#"]');
         const menuToggle = document.getElementById('menu-toggle');
@@ -136,6 +146,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Determine and set the initial language
     const initialLang = getInitialLanguage();
     applyTranslations(initialLang);
+    setLangIcon(initialLang);
 
     // Listen for language changes
     if (langSelect) {
@@ -143,6 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const newLang = langSelect.value;
             localStorage.setItem('lang', newLang);
             applyTranslations(newLang);
+            setLangIcon(newLang);
         });
     }
 

--- a/index.tsx
+++ b/index.tsx
@@ -79,6 +79,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const supportedLangs = ['en', 'tr', 'ar'];
     const defaultLang = 'tr';
 
+    const arrowIcon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23a8b2d1'%3E%3Cpath d='M6 9.25a.75.75 0 01-.53-.22l-3-3a.75.75 0 011.06-1.06L6 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-.53.22z'/%3E%3C/svg%3E";
+    const iconMap: Record<string, string> = { en: 'en.png', tr: 'tr.png', ar: 'ar.png' };
+    const setLangIcon = (lang: string): void => {
+        if (!langSelect) return;
+        const icon = iconMap[lang];
+        if (icon) {
+            langSelect.style.backgroundImage = `url(${icon}), url(${arrowIcon})`;
+        }
+    };
+
     const setupNavigation = (): void => {
         const navLinks = document.querySelectorAll('.main-nav a[href^="#"]');
         const menuToggle = document.getElementById('menu-toggle') as HTMLInputElement;
@@ -139,6 +149,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Determine and set the initial language
     const initialLang = getInitialLanguage();
     applyTranslations(initialLang);
+    setLangIcon(initialLang);
     
     // Listen for language changes
     if (langSelect) {
@@ -146,6 +157,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const newLang = langSelect.value;
             localStorage.setItem('lang', newLang);
             applyTranslations(newLang);
+            setLangIcon(newLang);
         });
     }
     


### PR DESCRIPTION
## Summary
- Replace emoji flags in language dropdown with PNG icons for Turkish, English and Arabic
- Style language selector and options to display icon images
- Update scripts to swap icons as user changes language

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9e1ee975c832fa002baca7722143d