### PR TITLE
Fix flag icons and RTL header layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/index.css
+++ b/index.css
@@ -187,13 +187,35 @@ img {
 }
 
 /* --- RTL Support --- */
+html[dir="rtl"] .logo {
+    flex-direction: row-reverse;
+}
+
 html[dir="rtl"] .header-content {
     flex-direction: row-reverse;
 }
 
 html[dir="rtl"] .main-nav {
-    margin-left: 0;
-    margin-right: auto;
+    flex-direction: row-reverse;
+    margin-inline-start: 0;
+    margin-inline-end: auto;
+}
+
+html[dir="rtl"] .main-nav ul {
+    flex-direction: row-reverse;
+}
+
+html[dir="rtl"] .main-nav a:not(.lang-link)::after {
+    transform-origin: left;
+}
+
+html[dir="rtl"] .main-nav a:not(.lang-link):hover::after,
+html[dir="rtl"] .main-nav a:not(.lang-link):focus::after {
+    transform-origin: right;
+}
+
+html[dir="rtl"] .lang-select {
+    background-position: right 0.4rem center, left 0.75rem center;
 }
 
 
@@ -202,8 +224,49 @@ html[dir="rtl"] .main-nav {
     display: flex;
     gap: var(--spacing-s);
     align-items: center;
-    margin-left: var(--spacing-m);
+    margin-inline-start: var(--spacing-m);
 }
+
+.lang-select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: transparent;
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-text-secondary);
+    padding-block: var(--spacing-xs);
+    padding-inline-start: 2rem;
+    padding-inline-end: 2.2rem;
+    border-radius: 4px;
+    font-family: var(--font-sans);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: color var(--transition-speed) ease, border-color var(--transition-speed) ease;
+    background-image: url('tr.png'), url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23a8b2d1'%3E%3Cpath d='M6 9.25a.75.75 0 01-.53-.22l-3-3a.75.75 0 011.06-1.06L6 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-.53.22z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat, no-repeat;
+    background-position: 0.4rem center, right 0.75rem center;
+    background-size: 1rem auto, 12px;
+}
+
+.lang-select:hover,
+.lang-select:focus {
+    color: var(--color-text-primary);
+    border-color: var(--color-accent);
+}
+
+.lang-select option {
+    background-color: var(--color-background);
+    color: var(--color-text-primary);
+    padding-inline-start: 2rem;
+    background-repeat: no-repeat;
+    background-position: 0.4rem center;
+    background-size: 1rem auto;
+}
+
+.lang-select option[value="tr"] { background-image: url('tr.png'); }
+.lang-select option[value="en"] { background-image: url('en.png'); }
+.lang-select option[value="ar"] { background-image: url('ar.png'); }
 
 .lang-link {
     font-size: 0.9rem;

--- a/index.tsx
+++ b/index.tsx
@@ -80,7 +80,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const defaultLang = 'tr';
 
     const arrowIcon = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23a8b2d1'%3E%3Cpath d='M6 9.25a.75.75 0 01-.53-.22l-3-3a.75.75 0 011.06-1.06L6 7.94l2.47-2.47a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-.53.22z'/%3E%3C/svg%3E";
-    const iconMap: Record<string, string> = { en: 'en.png', tr: 'tr.png', ar: 'ar.png' };
+    const iconMap: Record<string, string> = {
+        en: new URL('./en.png', import.meta.url).href,
+        tr: new URL('./tr.png', import.meta.url).href,
+        ar: new URL('./ar.png', import.meta.url).href
+    };
     const setLangIcon = (lang: string): void => {
         if (!langSelect) return;
         const icon = iconMap[lang];


### PR DESCRIPTION
## Summary
- Ensure flag icons are bundled and shown in the language selector
- Reverse header layout and navigation for Arabic (RTL) locales
- Style language dropdown with flag icons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9e63afd28832fba8228e322d754ac